### PR TITLE
Remove diagnostic_namespace from unstable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,6 @@
 #![cfg_attr(
     all(feature = "unstable", nightly),
     feature(
-        diagnostic_namespace,
         lint_reasons,
         multiple_supertrait_upcastable,
         must_not_suspend,
@@ -226,7 +225,7 @@
         must_not_suspend,
         non_exhaustive_omitted_patterns,
         unfulfilled_lint_expectations,
-        unknown_or_malformed_diagnostic_attributes,
+        // unknown_or_malformed_diagnostic_attributes,
         unnameable_types,
     )
 )]


### PR DESCRIPTION
* Remove `diagnostic_namespace` from unstable as it has been stabilized.