### PR TITLE
Removed lint that was converted to a hard error, updated to mongodb 3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 name = "bb8-mongodb"
 readme = "README.md"
 repository = "https://github.com/rustyhorde/bb8-mongodb"
-version = "0.2.4"
+version = "1.0.0"
 rust-version = "1.72.1"
 
 [package.metadata.cargo-all-features]
@@ -27,7 +27,7 @@ unstable = []
 anyhow = "1.0.79"
 async-trait = "0.1.77"
 bb8 = "0.8.3"
-mongodb = "2.8.0"
+mongodb = "3.0.1"
 thiserror = "1.0.56"
 tokio = { version = "1.35.1", features = ["full"] }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@
 //! let conn = pool.get().await?;
 //! assert_eq!(conn.name(), "admin");
 //! // Run a command
-//! let doc = conn.run_command(doc! { "ping": 1 }, None).await?;
+//! let doc = conn.run_command(doc! { "ping": 1 }).await?;
 //! // Check the result
 //! assert_eq!(doc! { "ok": 1 }, doc);
 //! # Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,8 +210,7 @@
         useless_ptr_null_checks,
         variant_size_differences,
         wasm_c_abi,
-        while_true,
-        writes_through_immutable_pointer,
+        while_true
     )
 )]
 // If nightly and unstable, allow `incomplete_features` and `unstable_features`

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -45,7 +45,7 @@ impl ManageConnection for Mongodb {
     }
 
     async fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
-        let _doc = conn.run_command(doc! { "ping": 1 }, None).await?;
+        let _doc = conn.run_command(doc! { "ping": 1 }).await?;
         Ok(())
     }
 
@@ -85,7 +85,7 @@ mod test {
         let conn = pool.get().await?;
         assert_eq!(conn.name(), "admin");
         // Run a command
-        let doc = conn.run_command(doc! { "ping": 1 }, None).await?;
+        let doc = conn.run_command(doc! { "ping": 1 }).await?;
         // Check the result
         assert_eq!(doc! { "ok": 1 }, doc);
         Ok(())


### PR DESCRIPTION
* Updated to `mongo` 3.0
* Removed a lint that was converted to a hard error.